### PR TITLE
PKG-1181: Update for v2021.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.6.0" %}
+{% set version = "2021.7.0" %}
 
 {% set vmajor = version.split('.')[0]|int %}
 {% set vminor = version.split('.')[1]|int %}
@@ -38,10 +38,10 @@ package:
 source:
   fn: {{ vtag }}.tar.gz
   url: https://github.com/oneapi-src/oneTBB/archive/{{ vtag }}.tar.gz
-  sha256: 4897dd106d573e9dacda8509ca5af1a0e008755bf9c383ef6777ac490223031f
+  sha256: 2cae2a80cda7d45dc7c072e4295c675fff5ad8316691f26f40539f7e7e54c0cc
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,8 +48,6 @@ requirements:
     - python
     - {{ compiler('cxx') }}
     - git
-    - patch  # [not win]
-    - m2-patch  # [win]
     - ninja  # [win]
     - make   # [not win]
     - cmake


### PR DESCRIPTION
Jira: https://anaconda.atlassian.net/browse/PKG-1181

Linter errors for the `tbb` output package should be disregarded because this output is a binary repack.
