### PR TITLE
Update 2021.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,6 +71,14 @@ outputs:
       missing_dso_whitelist:
         - "$RPATH/libtbbmalloc.so.2"  # [ppc64le]
         - "*/ld64.so.1"               # [s390x]
+    requirements:
+      build:
+        - python
+        - {{ compiler('cxx') }}
+        - git
+        - ninja  # [win]
+        - make   # [not win]
+        - cmake
 
   - name: tbb-devel
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@
 {% set tbb4py_build_dir = 'build_py%PY_VER%h%PKG_HASH%' %}  # [win]
 
 package:
-  name: tbb
+  name: tbb-split
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -141,7 +141,9 @@ outputs:
     test:
       requires:
         - python
-        - {{ pin_subpackage('tbb', exact=True) }}        # we want to test with this specific tbb package
+        - tbb {{ version }}                                # we want to test with this specific tbb package.
+                                                           # This will resolve to the most recent build number of this
+                                                           # package version, which will be the one just built.
       imports:
         - tbb
         - TBB

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ build:
 
 requirements:
   build:
-    - python
     - {{ compiler('cxx') }}
     - ninja  # [win]
     - make   # [not win]
@@ -72,7 +71,6 @@ outputs:
         - "*/ld64.so.1"               # [s390x]
     requirements:
       build:
-        - python
         - {{ compiler('cxx') }}
         - ninja  # [win]
         - make   # [not win]
@@ -89,7 +87,6 @@ outputs:
         - tbb >={{ version }}
     requirements:
       build:
-        - python
         - {{ compiler('cxx') }}
         - ninja  # [win]
         - make   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ vtag }}.tar.gz
   url: https://github.com/oneapi-src/oneTBB/archive/{{ vtag }}.tar.gz
   sha256: eee380323bb7ce864355ed9431f85c43955faaae9e9bce35c62b372d7ffd9f8b
 
@@ -141,9 +140,6 @@ outputs:
     test:
       requires:
         - python
-        - tbb {{ version }}                                # we want to test with this specific tbb package.
-                                                           # This will resolve to the most recent build number of this
-                                                           # package version, which will be the one just built.
       imports:
         - tbb
         - TBB
@@ -168,7 +164,7 @@ about:
     oneTBB is a flexible C++ library that simplifies the work of adding parallelism to complex applications, even if you
     are not a threading expert.
   dev_url: https://github.com/oneapi-src/oneTBB
-  doc_url: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onetbb.html
+  doc_url: https://oneapi-src.github.io/oneTBB/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -162,6 +162,9 @@ about:
     - LICENSE.txt
     - third-party-programs.txt
   summary: High level abstract threading library
+  description: |
+    oneTBB is a flexible C++ library that simplifies the work of adding parallelism to complex applications, even if you
+    are not a threading expert.
   dev_url: https://github.com/oneapi-src/oneTBB
   doc_url: https://software.intel.com/en-us/oneapi-tbb-documentation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,6 @@ requirements:
   build:
     - python
     - {{ compiler('cxx') }}
-    - git
     - ninja  # [win]
     - make   # [not win]
     - cmake
@@ -75,7 +74,6 @@ outputs:
       build:
         - python
         - {{ compiler('cxx') }}
-        - git
         - ninja  # [win]
         - make   # [not win]
         - cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    # the ninja cmake generator only works on windows, for some reason
     - ninja  # [win]
     - make   # [not win]
     - cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,14 +50,6 @@ requirements:
     - make   # [not win]
     - cmake
 
-test:
-  requires:
-    - python
-  commands:
-    - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'libtbb.so.{{ vbinary }}.{{ vminor }}']       ['TBB_runtime_interface_version']()"  # [linux]
-    - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'libtbb.{{ vbinary }}.{{ vminor }}${SHLIB_EXT}']['TBB_runtime_interface_version']()"  # [unix and not linux]
-    - python -c "import ctypes, os; os.add_dll_directory(os.environ['LIBRARY_BIN']); assert {{ vinterface }} == ctypes.cdll[r'tbb{{ vbinary }}.dll'] ['TBB_runtime_interface_version']()"  # [win]
-
 outputs:
   - name: tbb
     build:
@@ -75,6 +67,13 @@ outputs:
         - ninja  # [win]
         - make   # [not win]
         - cmake
+    test:
+      requires:
+        - python
+      commands:
+        - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'libtbb.so.{{ vbinary }}.{{ vminor }}']       ['TBB_runtime_interface_version']()"  # [linux]
+        - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'libtbb.{{ vbinary }}.{{ vminor }}${SHLIB_EXT}']['TBB_runtime_interface_version']()"  # [unix and not linux]
+        - python -c "import ctypes, os; os.add_dll_directory(os.environ['LIBRARY_BIN']); assert {{ vinterface }} == ctypes.cdll[r'tbb{{ vbinary }}.dll'] ['TBB_runtime_interface_version']()"  # [win]
 
   - name: tbb-devel
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -166,7 +166,7 @@ about:
     oneTBB is a flexible C++ library that simplifies the work of adding parallelism to complex applications, even if you
     are not a threading expert.
   dev_url: https://github.com/oneapi-src/oneTBB
-  doc_url: https://software.intel.com/en-us/oneapi-tbb-documentation
+  doc_url: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onetbb.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.7.0" %}
+{% set version = "2021.8.0" %}
 
 {% set vmajor = version.split('.')[0]|int %}
 {% set vminor = version.split('.')[1]|int %}
@@ -38,7 +38,7 @@ package:
 source:
   fn: {{ vtag }}.tar.gz
   url: https://github.com/oneapi-src/oneTBB/archive/{{ vtag }}.tar.gz
-  sha256: 2cae2a80cda7d45dc7c072e4295c675fff5ad8316691f26f40539f7e7e54c0cc
+  sha256: eee380323bb7ce864355ed9431f85c43955faaae9e9bce35c62b372d7ffd9f8b
 
 build:
   number: 0


### PR DESCRIPTION
# Links

[Upstream](https://github.com/oneapi-src/oneTBB)
[Upstream update diff](https://github.com/oneapi-src/oneTBB/compare/v2021.7.0...v2021.8.0)
[Conda-forge update diff](https://github.com/conda-forge/tbb-feedstock/compare/e077d70432771162228359c4c9fc81fb987c081b..435de0a0ea2f111ee49d7ba6bd308afd926eb13a)
[Changelog](https://github.com/oneapi-src/oneTBB/blob/master/RELEASE_NOTES.md)
[Jira ticket](https://anaconda.atlassian.net/browse/PKG-1344)
[License](https://github.com/oneapi-src/oneTBB/blob/master/LICENSE.txt)

# Changes
- Bump version, update checksum
- Change pin_subpackage to an explicit pinning to solve unresolvability error during tbb4py testing. `Pin_subpackage(exact=True)` uses the package hash, which will never be resolveable with a
pinning specified using an equality.
- lint addressing:
  - Rename top-level package so it's different from the main package name
  - Add requirements to main output, copied from top-level package
  - Move main output test to main output section, not top-level section
  - Add description
  - Update doc_url, previous was a redirect to docs for an older version
  - Remaining lints are erroneous and have been reported as issues
- other cleanup:
  - Remove unneeded git and python dependencies


# Further notes
- No changes to dependencies or build system interface upstream. No relevant changes in conda-forge either.
