### PR TITLE
Update to 2022.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/0001-Avoid-creating-python-eggs.patch
+++ b/recipe/0001-Avoid-creating-python-eggs.patch
@@ -1,0 +1,78 @@
+From 1df9b67b7f3ee56dd210bf33d6045bb440305f7c Mon Sep 17 00:00:00 2001
+From: Brian Wing <bwing@anaconda.com>
+Date: Thu, 6 Feb 2025 09:34:18 -0500
+Subject: [PATCH] Avoid creating python eggs
+
+---
+ python/CMakeLists.txt | 35 +++++++++++++++++++----------------
+ python/setup.py       |  1 +
+ 2 files changed, 20 insertions(+), 16 deletions(-)
+
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 748921a5..abf18441 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -32,29 +32,32 @@ foreach(dir ${TBB_INCLUDES})
+ endforeach()
+ string(STRIP "${TBB4PY_INCLUDE_STRING}" TBB4PY_INCLUDE_STRING)
+ 
+-add_custom_target(
+-    python_build
+-    ALL
+-    DEPENDS tbb python_copy
+-    COMMAND
+-    ${PYTHON_EXECUTABLE} ${PYTHON_BUILD_WORK_DIR}/setup.py
+-        build -b${PYTHON_BUILD_WORK_DIR}
+-        build_ext ${TBB4PY_INCLUDE_STRING} -L$<TARGET_FILE_DIR:TBB::tbb>
+-        install --prefix build -f
+-    COMMENT "Build and install to work directory the oneTBB Python module"
+-)
+-
+ add_test(NAME python_test
+          COMMAND ${CMAKE_COMMAND}
+                  -DTBB_BINARIES_PATH=$<TARGET_FILE_DIR:TBB::tbb>
+                  -DPYTHON_MODULE_BUILD_PATH=${PYTHON_BUILD_WORK_DIR}/build
+                  -P ${PROJECT_SOURCE_DIR}/cmake/python/test_launcher.cmake)
+ 
+-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_BUILD_WORK_DIR}/build/
+-        DESTINATION .
+-        COMPONENT tbb4py)
+-
+ if (UNIX AND NOT APPLE)
++    add_custom_target(
++            python_build
++            ALL
++            DEPENDS tbb python_copy
++            COMMAND
++            IRML_LIB_DIR="$<TARGET_FILE_DIR:TBB::irml>"
++            ${PYTHON_EXECUTABLE} -m pip install --no-deps --no-build-isolation -vv ${PYTHON_BUILD_WORK_DIR}/.
++            COMMENT "Build and install to work directory the oneTBB Python module"
++    )
++
+     add_subdirectory(rml)
+     add_dependencies(python_build irml)
++else()
++    add_custom_target(
++            python_build
++            ALL
++            DEPENDS tbb python_copy
++            COMMAND
++            ${PYTHON_EXECUTABLE} -m pip install --no-deps --no-build-isolation -vv ${PYTHON_BUILD_WORK_DIR}/.
++            COMMENT "Build and install to work directory the oneTBB Python module"
++    )
+ endif()
+diff --git a/python/setup.py b/python/setup.py
+index edf8580f..ea6f3c6c 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -69,6 +69,7 @@ _tbb = Extension("tbb._api", ["tbb/api.i"],
+                        os.path.join(tbb_root, 'lib', 'intel64', 'gcc4.8'),  # for Linux
+                        os.path.join(tbb_root, 'lib'),                       # for MacOS
+                        os.path.join(tbb_root, 'lib', 'intel64', 'vc_mt'),   # for Windows
++                       os.getenv('IRML_LIB_DIR', '../..').strip("\""),
+                      ] if not use_compiler_tbb else [],
+         language    ='c++',
+         )
+-- 
+2.39.5 (Apple Git-154)
+

--- a/recipe/fix-build-gcc-13.3.patch
+++ b/recipe/fix-build-gcc-13.3.patch
@@ -1,0 +1,26 @@
+diff --git a/include/oneapi/tbb/detail/_flow_graph_impl.h b/include/oneapi/tbb/detail/_flow_graph_impl.h
+index 19e00a8e..55063b93 100644
+--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
++++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
+@@ -347,7 +347,7 @@ public:
+         caught_exception = false;
+         try_call([this] {
+             my_task_arena->execute([this] {
+-                wait(my_wait_context_vertex.get_context(), *my_context);
++                d1::wait(my_wait_context_vertex.get_context(), *my_context);
+             });
+             cancelled = my_context->is_group_execution_cancelled();
+         }).on_exception([this] {
+diff --git a/include/oneapi/tbb/flow_graph.h b/include/oneapi/tbb/flow_graph.h
+index 20916fa7..5b438faa 100644
+--- a/include/oneapi/tbb/flow_graph.h
++++ b/include/oneapi/tbb/flow_graph.h
+@@ -305,7 +305,7 @@ public:
+         bool res = internal_try_put(t, message_metainfo{message_metainfo::waiters_type{&msg_wait_vertex}});
+         if (res) {
+             __TBB_ASSERT(graph_reference().my_context != nullptr, "No wait_context associated with the Flow Graph");
+-            wait(msg_wait_vertex.get_context(), *graph_reference().my_context);
++            d1::wait(msg_wait_vertex.get_context(), *graph_reference().my_context);
+         }
+         return res;
+     }

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = "2021.8.0" %}
+{% set version = "2022.0.0" %}
 
 {% set vmajor = version.split('.')[0]|int %}
 {% set vminor = version.split('.')[1]|int %}
 {% set vpatch = version.split('.')[2]|int %}
 {% set vbinary = vmajor - 2009 %}
 
-{% set vtag = "v%d.%d.%d" % (vmajor, vminor, vpatch) %}
+{% set vtag = "v" ~ version.replace(".rc", "-rc") %}
 
 # Official patch version for the first release of 2021 is 1,
 # but internal patch version is 0, handle it for interface version.
@@ -15,70 +15,91 @@
 # tbb4py files should be installed into PREFIX.
 # See https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html.
 # On non-Windows CMAKE_ARGS already contains CMAKE_INSTALL_PREFIX.
-{% set cmake_args = "$CMAKE_ARGS -DPython3_EXECUTABLE=${PYTHON} -DPYTHON_EXECUTABLE=${PYTHON}" %}  # [not win and not ppc64le] 
-{% set cmake_args = "$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DPython3_EXECUTABLE=${PYTHON} -DPYTHON_EXECUTABLE=${PYTHON}" %}  # [ppc64le]
-{% set cmake_args = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DPython3_EXECUTABLE=%PYTHON% -DPYTHON_EXECUTABLE=%PYTHON%" %}  # [win]
-
-{% set cmake_tbb4py_args = "$CMAKE_ARGS -DPython3_EXECUTABLE=${PYTHON} -DPYTHON_EXECUTABLE=${PYTHON}" %}  # [not win and not ppc64le]
-{% set cmake_tbb4py_args = "$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DPython3_EXECUTABLE=${PYTHON} -DPYTHON_EXECUTABLE=${PYTHON}" %}  # [ppc64le]
-{% set cmake_tbb4py_args = "-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX% -DPython3_EXECUTABLE=%PYTHON% -DPYTHON_EXECUTABLE=%PYTHON%" %}   # [win]
+{% if win %}
+    {% set cmake_args = "%CMAKE_ARGS% -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%" %}
+    {% set cmake_tbb4py_args = "%CMAKE_ARGS% -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX%" %}
+{% else %}
+    {% set cmake_args = "$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release" %}
+    {% set cmake_tbb4py_args = "$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release" %}
+{% endif %}
 
 # Use specific test list agreed with TBB team to cover core functionality on high level.
 # Execution of all tests is too heavy task for packaging CI.
-{% set tests = "test_parallel_for test_tbb_header conformance_version test_malloc_compliance test_flow_graph test_arena_constraints" %}
+# test_malloc_compliance is temporary excluded from the list since it causes failures that likely appear due to test implementation or env misconfiguration.
+# oneTBB issue: https://github.com/oneapi-src/oneTBB/issues/700
+# Agreed with oneTBB developers that it is suitable approach since the product is fully tested on oneTBB side.
+{% set tests = "test_parallel_for test_tbb_header conformance_version test_flow_graph test_arena_constraints" %}
 {% set ctest_regex = "^(%s)$" % (tests.replace(' ', '|')) %}
 
-{% set tbb4py_build_dir = 'build_py${PY_VER}h${PKG_HASH}' %}   # [not win]
-{% set tbb4py_build_dir = 'build_py%PY_VER%h%PKG_HASH%' %}  # [win]
+{% set tbb4py_build_dir = "build_py${PY_VER}h${PKG_HASH}" %}  # [not win]
+{% set tbb4py_build_dir = "build_py%PY_VER%h%PKG_HASH%" %}    # [win]
 
 package:
-  name: tbb-split
+  name: tbb
   version: {{ version }}
 
 source:
-  url: https://github.com/oneapi-src/oneTBB/archive/{{ vtag }}.tar.gz
-  sha256: eee380323bb7ce864355ed9431f85c43955faaae9e9bce35c62b372d7ffd9f8b
+  url: https://github.com/oneapi-src/oneTBB/archive/refs/tags/{{ vtag }}.tar.gz
+  sha256: e8e89c9c345415b17b30a2db3095ba9d47647611662073f7fbf54ad48b7f3c2a
+  patches:
+    - fix-build-gcc-13.3.patch
+    - 0001-Avoid-creating-python-eggs.patch
 
 build:
   number: 0
 
 requirements:
   build:
+    - python
     - {{ compiler('cxx') }}
     # the ninja cmake generator only works on windows, for some reason
-    - ninja  # [win]
-    - make   # [not win]
+    - ninja     # [win]
+    - m2-patch  # [win]
+    - patch     # [not win]
+    - make      # [not win]
     - cmake
+    - pkg-config
 
 outputs:
   - name: tbb
+    about:
+      summary: TBB Libraries
+      license_file:
+        - LICENSE.txt
+        - third-party-programs.txt
     build:
       script:
-        - set CMAKE_GENERATOR=Ninja  # [win]
+        - set CMAKE_GENERATOR=Ninja      # [win]
+        # unset option that ninja complains about
+        - set CMAKE_GENERATOR_TOOLSET=   # [win]
+        - set CMAKE_GENERATOR_PLATFORM=  # [win]
         - cmake {{ cmake_args }} -DTBB_TEST=OFF -S . -B build
         - cmake --build build --parallel
         - cmake -DCOMPONENT=runtime -P build/cmake_install.cmake
       missing_dso_whitelist:
-        - "$RPATH/libtbbmalloc.so.2"  # [ppc64le]
         - "*/ld64.so.1"               # [s390x]
     requirements:
-      build:
-        - {{ compiler('cxx') }}
-        - ninja  # [win]
-        - make   # [not win]
-        - cmake
     test:
       requires:
         - python
       commands:
-        - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'libtbb.so.{{ vbinary }}.{{ vminor }}']       ['TBB_runtime_interface_version']()"  # [linux]
-        - python -c "import ctypes; assert {{ vinterface }} == ctypes.cdll[r'libtbb.{{ vbinary }}.{{ vminor }}${SHLIB_EXT}']['TBB_runtime_interface_version']()"  # [unix and not linux]
-        - python -c "import ctypes, os; os.add_dll_directory(os.environ['LIBRARY_BIN']); assert {{ vinterface }} == ctypes.cdll[r'tbb{{ vbinary }}.dll'] ['TBB_runtime_interface_version']()"  # [win]
+        {% set libname = "libtbb.so." ~ vbinary ~ "." ~ vminor %}          # [linux]
+        {% set libname = "libtbb." ~ vbinary ~ "." ~ vminor ~ ".dylib" %}  # [osx]
+        {% set libname = "tbb" ~ vbinary ~ ".dll" %}                       # [win]
+        {% set win_extra = "os.add_dll_directory(os.environ['LIBRARY_BIN']); " if win else "" %}
+        - python -c "import ctypes, os; {{ win_extra }} assert {{ vinterface }} == ctypes.cdll[r'{{ libname }}']['TBB_runtime_interface_version']()"
 
   - name: tbb-devel
+    about:
+      summary: TBB Development files
+      license_file:
+        - LICENSE.txt
+        - third-party-programs.txt
     build:
       script:
-        - set CMAKE_GENERATOR=Ninja  # [win]
+        - set CMAKE_GENERATOR=Ninja      # [win]
+        - set CMAKE_GENERATOR_TOOLSET=   # [win]
+        - set CMAKE_GENERATOR_PLATFORM=  # [win]
         - cmake {{ cmake_args }} -DTBB_TEST=OFF -S . -B build
         - cmake --build build --parallel
         - cmake -DCOMPONENT=devel -P build/cmake_install.cmake
@@ -86,11 +107,12 @@ outputs:
         - tbb >={{ version }}
     requirements:
       build:
+        - python
         - {{ compiler('cxx') }}
         - ninja  # [win]
         - make   # [not win]
         - cmake >=3.13
-
+        - pkg-config
       run:
         - {{ pin_subpackage('tbb', exact=True) }}        # development package is for specific version of tbb
     test:
@@ -99,41 +121,55 @@ outputs:
         - ninja  # [win]
         - make   # [not win]
         - cmake
+        - pkg-config
       source_files:
         - cmake
         - test
         - CMakeLists.txt
         - include  # some tests depend on files from include
+        - integration  # same
         - src      # some tests depend on files from src
       commands:
-        - set CMAKE_GENERATOR=Ninja  # [win]
-        # Setting TBB_DIR=TRUE is needed to use libraries from the tested package,
+        - set CMAKE_GENERATOR=Ninja      # [win]
+        - set CMAKE_GENERATOR_TOOLSET=   # [win]
+        - set CMAKE_GENERATOR_PLATFORM=  # [win]
+        # Setting TBB_DIR=ON and TBB_FIND_PACKAGE=ON is needed to use libraries from the tested package,
         # but do not build them from sources; real path to TBBConfig files is not required,
         # because CMake will successfully find installed tested package.
-        - cmake {{ cmake_args }} -DTBB_TEST=ON -DTBB_DIR=TRUE -S . -B test_build
+        - cmake {{ cmake_args }} -DTBB_TEST=ON -DTBB_DIR=ON -DTBB_FIND_PACKAGE=ON -S . -B test_build
         - cmake --build test_build --target {{ tests }} --parallel  # build tests
         - cd test_build
         - ctest -R "{{ ctest_regex }}" --output-on-failure
 
   - name: tbb4py
+    about:
+      summary: TBB module for Python
+      license: Apache-2.0
+      license_file:
+        - LICENSE.txt
+        - third-party-programs.txt
+      dev_url: https://github.com/oneapi-src/oneTBB/tree/master/python
     build:
       script:
-        - set CMAKE_GENERATOR=Ninja  # [win]
+        - set CMAKE_GENERATOR=Ninja      # [win]
+        - set CMAKE_GENERATOR_TOOLSET=   # [win]
+        - set CMAKE_GENERATOR_PLATFORM=  # [win]
+        - export PYTHONPATH="${SP_DIR/${PREFIX}/build}"  # [osx]
         - cmake {{ cmake_tbb4py_args }} -DTBB4PY_BUILD=ON -DTBB_TEST=OFF -S . -B {{ tbb4py_build_dir }}
         - cmake --build {{ tbb4py_build_dir }} --target python_build --parallel
         - cmake -DCOMPONENT=tbb4py -P {{ tbb4py_build_dir }}/cmake_install.cmake
       missing_dso_whitelist:
-        - "$RPATH/libtbb.so.12"  # [ppc64le]
         - "*/ld64.so.1"          # [s390x]
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - ninja  # [win]
         - make   # [not win]
         - cmake
-        - swig >=3.0.6
+        - swig
       host:
         - python
+        - pip
+        - setuptools
         - {{ pin_subpackage('tbb-devel', exact=True) }}
       run:
         - tbb >={{ version }}                            # while python module works with any compatible tbb...
@@ -141,6 +177,7 @@ outputs:
     test:
       requires:
         - python
+        - {{ pin_subpackage('tbb', exact=True) }}        # we want to test with this specific tbb package
       imports:
         - tbb
         - TBB
@@ -148,10 +185,6 @@ outputs:
         - python -m TBB -h
         - python -m tbb -h
         - python -m tbb test
-    about:
-      summary: TBB module for Python
-      license: Apache-2.0
-      dev_url: https://github.com/oneapi-src/oneTBB/tree/master/python
 
 about:
   home: https://github.com/oneapi-src/oneTBB
@@ -165,10 +198,16 @@ about:
     oneTBB is a flexible C++ library that simplifies the work of adding parallelism to complex applications, even if you
     are not a threading expert.
   dev_url: https://github.com/oneapi-src/oneTBB
-  doc_url: https://oneapi-src.github.io/oneTBB/
+  doc_url: https://software.intel.com/en-us/oneapi-tbb-documentation
 
 extra:
+  skip-lints:
+    - wrong_output_script_key
+    - outputs_not_unique
+    - missing_section
   recipe-maintainers:
     - anton-malakhov
     - jschueller
     - AlexVeprev
+    - isaevil
+    - ilya-lavrenov


### PR DESCRIPTION
tbb 2022.0.0

**Destination channel:** defaults

### Links

- [PKG-6978](https://anaconda.atlassian.net/browse/PKG-6978)
- [Upstream repository](https://github.com/uxlfoundation/oneTBB/tree/v2022.0.0)
- [Upstream changelog/diff](https://github.com/uxlfoundation/oneTBB/releases/tag/v2022.0.0)
- Relevant dependency PRs:
  - AnacondaRecipes/intel-compilers-repack-feedstock#11
  - AnacondaRecipes/intel_repack-feedstock#26

### Explanation of changes:

- Synced recipe with conda-forge
- Added patch to install python package as a wheel instead of an egg to avoid pathing issues with deprecated egg format


[PKG-6978]: https://anaconda.atlassian.net/browse/PKG-6978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ