### PR TITLE
Update version to 2023.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "tbb" %}
 {% set version = "2023.0.0" %}
 
-# https://github.com/uxlfoundation/oneTBB/blob/f1862f38f83568d96e814e469ab61f88336cc595/include/oneapi/tbb/version.h#L48
+# https://github.com/uxlfoundation/oneTBB/blob/v2023.0.0/include/oneapi/tbb/version.h#L48
 {% set vinterface = "12180" %}
 {% set vbinary = vinterface|int // 1000 %}
 {% set vminor = (vinterface|int % 1000 / 10)|int %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "tbb" %}
-{% set version = "2022.3.0" %}
+{% set version = "2023.0.0" %}
 
 # https://github.com/uxlfoundation/oneTBB/blob/f1862f38f83568d96e814e469ab61f88336cc595/include/oneapi/tbb/version.h#L48
-{% set vinterface = "12170" %}
+{% set vinterface = "12180" %}
 {% set vbinary = vinterface|int // 1000 %}
 {% set vminor = (vinterface|int % 1000 / 10)|int %}
 {% set vtag = "v" ~ version.replace(".rc", "-rc") %}
@@ -32,7 +32,7 @@ package:
 
 source:
   url: https://github.com/oneapi-src/oneTBB/archive/refs/tags/{{ vtag }}.tar.gz
-  sha256: 01598a46c1162c27253a0de0236f520fd8ee8166e9ebb84a4243574f88e6e50a
+  sha256: f8767b971ec6aea25dde58ae0f593e94e7aa75a739a86f67967012f69e2199b1
   patches:
     - 0001-fix-setup.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -115,6 +115,7 @@ outputs:
         - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
         - cmake
+        - pip
         - python
         - ninja-base
         - pkg-config


### PR DESCRIPTION
tbb 2023.0.0

**Destination channel: defaults

### Links

- [PKG-14530](https://anaconda.atlassian.net/browse/PKG-14530) 
- [Upstream repository](https://github.com/uxlfoundation/oneTBB/tree/v2023.0.0)

### Explanation of changes:
- New version number

[PKG-14530]: https://anaconda.atlassian.net/browse/PKG-14530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ